### PR TITLE
crash UIGraphicsBeginImageContextWithOptions on ios 17

### DIFF
--- a/Sources/UIGradientExtension.swift
+++ b/Sources/UIGradientExtension.swift
@@ -47,6 +47,9 @@ public extension UIColor {
 public extension UIImage {
     
     static func fromGradient(_ gradient: GradientLayer, frame: CGRect, cornerRadius: CGFloat = 0) -> UIImage? {
+        
+        guard frame.size.width > 0 && frame.size.height > 0 else { return nil }
+        
         UIGraphicsBeginImageContextWithOptions(frame.size, false, UIScreen.main.scale)
         guard let ctx = UIGraphicsGetCurrentContext() else { return nil }
         let cloneGradient = gradient.clone()


### PR DESCRIPTION
The crash is caused by calling UIGraphicsBeginImageContextWithOptions() with a size where either the width or height is 0. e.g. (0,0).